### PR TITLE
deprecation of erlang:now()

### DIFF
--- a/src/onewire_therm.erl
+++ b/src/onewire_therm.erl
@@ -136,7 +136,7 @@ read(Path) when is_list(Path) ->
 
 read(Binary) when is_binary(Binary) ->
   read(Binary, #therm{
-      timestamp = erlang:now()
+      timestamp = erlang:timestamp()
     }).
 
 read(<<A1:16,_,A2:16,_,A3:16,_,A4:16,_,A5:16,_,A6:16,_,A7:16,_,A8:16,_,CRC:16,_,$:,_,"crc=",CRC:16,_,"YES",Rest0/binary>>,


### PR DESCRIPTION
I'm trying to use this in a newer project (R18) and therefor I'm using the newer erlang:timestamp() and not the deprecated erlang:now().
